### PR TITLE
feat: add _redirects for /dotfiles install script

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/dotfiles/install.sh https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/install.sh 302


### PR DESCRIPTION
Adds a single `public/_redirects` so `romaingrx.com/dotfiles/install.sh` serves the [dotfiles](https://github.com/romaingrx/dotfiles) installer.

```
/dotfiles/install.sh  →  raw .../scripts/install.sh  (302)
```

```sh
curl -fsSL https://romaingrx.com/dotfiles/install.sh | HOST=<host> bash
```

## Why this approach
- Cloudflare Workers static assets natively support `_redirects`; the `@astrojs/cloudflare` adapter copies `public/` into the `dist/` assets dir.
- Served **at the edge** (before the SSR worker; `run_worker_first` unset). No worker code, no `astro.config` change, no dependency.

## Depends on
romaingrx/dotfiles#71 (renames `bootstrap.sh` → `install.sh`). **Merge that first** so `…/scripts/install.sh` resolves before this deploys.

## Test
`pnpm preview`, then `curl -sI http://localhost:8788/dotfiles/install.sh` → `302`.